### PR TITLE
Fix id-reuse collisions in the type-mapping cache

### DIFF
--- a/graphql_mcp/server.py
+++ b/graphql_mcp/server.py
@@ -60,6 +60,29 @@ _TYPE_MAPPING_CACHE: Dict[str, Any] = {}
 _CACHE_LOCK = threading.RLock()
 
 
+def _type_cache_key(prefix: str, graphql_type: Any) -> str:
+    """Build a cache key for an object/input type.
+
+    Keying by ``id(graphql_type)`` alone is unsafe: ``id`` is only unique
+    among live objects, so a garbage-collected type can have its address
+    reused by a differently-shaped type with the same name, yielding a stale
+    cache hit (e.g. a ``User`` with ``{name, age}`` served for a later
+    ``User`` with ``{name, nickname}``). We therefore combine ``id`` with a
+    shallow structural signature of the type's fields (name + ``str(field
+    type)`` for each field). The signature disambiguates reused ids — a
+    reused address with a different shape produces a different key and a
+    correct cache miss — while ``id`` keeps distinct-but-identically-shaped
+    types from different schemas isolated (relevant when one process builds
+    many schemas, e.g. the Bridge). The signature is computed without
+    recursing into nested types, since ``str()`` of a GraphQL type yields its
+    full type expression (e.g. ``"[User!]!"``).
+    """
+    fields = getattr(graphql_type, "fields", {}) or {}
+    signature = ",".join(
+        f"{name}:{field.type}" for name, field in fields.items())
+    return f"{prefix}_{graphql_type.name}({signature})_{id(graphql_type)}"
+
+
 def _extract_bearer_token_from_context(ctx: Optional[Context]) -> Optional[str]:
     """
     Extract bearer token from MCP request context for REMOTE server forwarding.
@@ -500,8 +523,9 @@ def _map_graphql_type_to_python_type(graphql_type: Any, _cache: Optional[Dict[st
 
     if isinstance(graphql_type, GraphQLInputObjectType):
         # Check cache to prevent infinite recursion
-        # Use object id to make cache schema-specific (different schemas with same type name won't conflict)
-        cache_key = f"input_object_{graphql_type.name}_{id(graphql_type)}"
+        # Key by structure (not id) so different schemas with same type name
+        # don't conflict and GC'd-then-reused ids can't cause stale hits.
+        cache_key = _type_cache_key("input_object", graphql_type)
 
         # Thread-safe cache check
         with _CACHE_LOCK:
@@ -558,8 +582,9 @@ def _map_graphql_type_to_python_type(graphql_type: Any, _cache: Optional[Dict[st
 
     if isinstance(graphql_type, GraphQLObjectType):
         # Check cache to prevent infinite recursion
-        # Use object id to make cache schema-specific (different schemas with same type name won't conflict)
-        cache_key = f"object_{graphql_type.name}_{id(graphql_type)}"
+        # Key by structure (not id) so different schemas with same type name
+        # don't conflict and GC'd-then-reused ids can't cause stale hits.
+        cache_key = _type_cache_key("object", graphql_type)
 
         # Thread-safe cache check
         with _CACHE_LOCK:

--- a/tests/test_type_cache_id_reuse.py
+++ b/tests/test_type_cache_id_reuse.py
@@ -1,0 +1,98 @@
+"""
+Regression tests for the type-mapping cache key.
+
+The cache that backs ``_map_graphql_type_to_python_type`` used to key object
+and input-object types by ``f"{name}_{id(type)}"``. ``id()`` is only unique
+among *live* objects, so a garbage-collected GraphQL type can have its memory
+address reused by a differently-shaped type with the same name. That produced
+a stale cache hit — e.g. a ``User`` model with ``{name, age}`` returned for a
+later, unrelated ``User`` with ``{name, nickname}``. The failure was
+environment-dependent (it surfaced on CI but not every local run) because it
+hinges on the allocator reusing an address.
+
+These tests provoke id reuse deterministically and assert each distinct type
+maps to a model with its own fields.
+"""
+import gc
+
+import pytest
+from graphql import (
+    GraphQLObjectType,
+    GraphQLInputObjectType,
+    GraphQLInputField,
+    GraphQLField,
+    GraphQLString,
+    GraphQLInt,
+    GraphQLNonNull,
+)
+
+from graphql_mcp.server import _map_graphql_type_to_python_type
+
+
+def _make_user_object(second_field_name, second_field_type):
+    return GraphQLObjectType(
+        "User",
+        {
+            "name": GraphQLField(GraphQLNonNull(GraphQLString)),
+            second_field_name: GraphQLField(second_field_type),
+        },
+    )
+
+
+def _make_user_input(second_field_name, second_field_type):
+    return GraphQLInputObjectType(
+        "UserInput",
+        {
+            "name": GraphQLInputField(GraphQLNonNull(GraphQLString)),
+            second_field_name: GraphQLInputField(second_field_type),
+        },
+    )
+
+
+def _assert_no_collision_on_id_reuse(factory):
+    """Build alternating-shaped, same-named types until one reuses a freed id
+    with the *other* shape, asserting each maps to a model with its own fields.
+
+    Returns True if the id-reuse condition (the actual bug trigger) was
+    observed. CPython's allocator reuses a freed same-size block on the next
+    allocation, so this normally happens within a handful of iterations; the
+    high cap is just a safety net before we give up.
+    """
+    # Alternate shapes so a reused id lands on the *other* shape — exactly the
+    # condition that produced the stale-cache bug.
+    shapes = [("age", GraphQLInt), ("nickname", GraphQLString)]
+    seen_ids = {}
+
+    for i in range(2000):
+        field_name, field_type = shapes[i % 2]
+        obj = factory(field_name, field_type)
+        reused = id(obj) in seen_ids and seen_ids[id(obj)] != field_name
+        seen_ids[id(obj)] = field_name
+
+        model = _map_graphql_type_to_python_type(obj)
+        assert set(model.model_fields) == {"name", field_name}, (
+            f"iteration {i}: expected fields {{'name', {field_name!r}}}, "
+            f"got {set(model.model_fields)}"
+        )
+        # Drop references and force collection so the address can be reused.
+        del obj, model
+        gc.collect()
+
+        if reused:
+            # The bug condition has been exercised and the assertion above
+            # validated correctness — no need to keep looping.
+            return True
+    return False
+
+
+def test_object_type_same_name_different_shape_no_collision():
+    """Two same-named object types with different fields must not share a model,
+    even when the second reuses the first's (freed) id."""
+    if not _assert_no_collision_on_id_reuse(_make_user_object):
+        pytest.skip("allocator never reused an id on this platform")
+
+
+def test_input_type_same_name_different_shape_no_collision():
+    """Same as above for input object types (separate cache-key branch)."""
+    if not _assert_no_collision_on_id_reuse(_make_user_input):
+        pytest.skip("allocator never reused an id on this platform")


### PR DESCRIPTION
The type-mapping cache keyed object and input-object models by `{name}_{id(graphql_type)}`. `id()` is only unique among live objects, so a garbage-collected GraphQL type can have its address reused by a differently-shaped type with the same name, producing a stale cache hit (e.g. a `User` model with `{name, age}` served for a later, unrelated `User` with `{name, nickname}`). This surfaced as an environment-dependent CI failure in `test_required_vs_optional_fields` and could otherwise yield a wrong tool schema at runtime — notably in one process building many schemas (the Bridge).

Key the cache by a shallow structural signature (field name + `str(field type)`) combined with `id`. The signature disambiguates reused ids while `id` keeps distinct-but-identically-shaped types from different schemas isolated. The signature is computed without recursing into nested types.

Adds a deterministic regression test that provokes id reuse.


Claude-Session: https://claude.ai/code/session_01Lc6ExFnbNNJvyPQzguLuXZ