### PR TITLE
GraphiQL MCP plugin: honor an injected MCP endpoint override

### DIFF
--- a/graphql_mcp/templates/mcp_plugin.js
+++ b/graphql_mcp/templates/mcp_plugin.js
@@ -85,6 +85,16 @@
                 });
                 // Smart MCP URL detection - works with GraphiQL at any path
                 const getDefaultMcpUrl = () => {
+                    // Allow the host page to declare the MCP endpoint explicitly.
+                    // A proxy that serves GraphiQL at a different path than the
+                    // MCP server (e.g. graphql-mcp-bridge) injects this so the
+                    // plugin points at the canonical endpoint instead of
+                    // guessing "<current path>/mcp".
+                    if (typeof window.__GRAPHQL_MCP_URL__ === 'string' &&
+                        window.__GRAPHQL_MCP_URL__) {
+                        return window.__GRAPHQL_MCP_URL__;
+                    }
+
                     const currentUrl = new URL(window.location.href);
                     // Remove any existing query parameters and fragments
                     currentUrl.search = '';


### PR DESCRIPTION
## Summary

The GraphiQL MCP plugin guessed the MCP endpoint as `<current path>/mcp`. That's correct when GraphiQL is served at the site root, but wrong when it's served at a different path than the MCP server — e.g. behind [graphql-mcp-bridge](https://github.com/parob/graphql-mcp-bridge), where the explorer lives at `/mcp/<token>/graphql` while the MCP endpoint is the canonical `/mcp/<token>`. The plugin would fill its MCP box with `/mcp/<token>/graphql/mcp` instead of `/mcp/<token>`.

## Change

`getDefaultMcpUrl()` now returns `window.__GRAPHQL_MCP_URL__` when the host page sets it, falling back to the existing path-based guess otherwise. This lets a proxy declare the real endpoint explicitly, with **no change to default behavior** when the global is unset.

The bridge sets this global (injected into the explorer HTML) to the canonical `scheme://host/mcp/<token>`, so the plugin's MCP box shows the clean endpoint.

## Notes

- Single-line, backwards-compatible: unset global → identical behavior to before.
- Follow-up consumer change is on the bridge side (PR #2 there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lc6ExFnbNNJvyPQzguLuXZ)_