### PR TITLE
Fix docs Pages build + document library examples

### DIFF
--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -326,14 +326,34 @@ def _fetch_releases() -> list[dict] | None:
 
 
 def _clean_release_body(body: str) -> str:
-    """Strip auto-generated 'Full Changelog' boilerplate from release body."""
+    """Normalise a GitHub release body for inline rendering.
+
+    Strips GitHub's auto-generated scaffolding ("## What's Changed" headings
+    and "**Full Changelog**: ..." lines), drops blank lines and leading list
+    markers, and de-duplicates repeated lines (release notes are occasionally
+    pasted in twice). The result is a compact set of lines suitable for a
+    one-line blurb in the release history.
+    """
     if not body:
         return ""
-    # Remove "**Full Changelog**: https://..." lines
-    cleaned = re.sub(
-        r"\*\*Full Changelog\*\*:\s*https://[^\s]+", "", body
-    ).strip()
-    return cleaned
+    lines: list[str] = []
+    seen: set[str] = set()
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        # Drop GitHub's auto-generated scaffolding.
+        if re.match(r"#+\s*What'?s Changed", line, flags=re.IGNORECASE):
+            continue
+        if line.lower().startswith("**full changelog**"):
+            continue
+        # Drop leading list markers so the inline blurb reads cleanly.
+        line = re.sub(r"^[*\-]\s+", "", line)
+        if line in seen:
+            continue
+        seen.add(line)
+        lines.append(line)
+    return "\n".join(lines).strip()
 
 
 def _split_highlights(body: str) -> tuple[str, str]:

--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -357,6 +357,13 @@ def _md_inline_to_html(text: str) -> str:
     # Escape HTML first, then convert backtick code spans
     escaped = escape(text)
     escaped = re.sub(r'`([^`]+)`', r'<code>\1</code>', escaped)
+    # Collapse all whitespace (including newlines) to single spaces. A blank
+    # line inside a raw-HTML block terminates that block in markdown, which
+    # leaves the surrounding tag unclosed and breaks the VitePress/Vue
+    # compiler ("Element is missing end tag"). Keeping the content on one
+    # line makes the inlined release text safe regardless of how the upstream
+    # GitHub release body is formatted.
+    escaped = re.sub(r'\s+', ' ', escaped).strip()
     return escaped
 
 


### PR DESCRIPTION
## Why

PR #9 was merged at commit `7f79c72`, **before** the docs-build fix landed, so `main`'s **Deploy docs to GitHub Pages** workflow is currently broken (`api-reference.md:880` "Element is missing end tag"). This PR carries the follow-up commits that didn't make it into #9, plus some docs/examples polish.

## Changes

### Fix the docs Pages build
`docs/generate_reference.py` inlines each GitHub release body into a `<p class="release-body">…</p>` raw-HTML block. The **2.1.4** release body is multi-paragraph, and a blank line inside a raw-HTML block terminates that block in markdown — leaving the `<p>` unclosed, which the VitePress/Vue compiler rejects.

- Collapse all whitespace (incl. newlines) to single spaces in `_md_inline_to_html`, so inlined release text always stays on one line.
- Normalise each release body before inlining: strip GitHub scaffolding (`## What's Changed`, `**Full Changelog**: …`), drop blank lines and list markers, de-duplicate repeated lines (2.1.4 was pasted in twice). Release History now renders compact, readable entries.

### Examples + docs polish
- `examples/app.py`: remove the `Library:` prefix from the five per-library example cards (now just `graphql-api`, `Strawberry`, …).
- `docs/examples.md`: add a **GraphQL Library Examples** section — a table of all five (source + live demo links) and a note on native vs workaround `@mcp` support.
- `docs/strawberry-graphene.md`: link the runnable `library_strawberry.py` / `library_graphene.py` examples from the workaround guide.

## Verification

Reproduced the exact CI failure locally with the real 2.1.4 release body, then ran a full `npm run docs:build` / `vitepress build` → **BUILD_OK** with the fix. Example suite: 50 passed. No `Library:` text remains in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DthKuN8eHrjWpEGQGQJisp