### PR TITLE
Remove "Library:" prefix from example cards + document library examples

### DIFF
--- a/docs/public/examples.md
+++ b/docs/public/examples.md
@@ -4,7 +4,7 @@ title: "Examples"
 
 # Examples
 
-Four runnable examples ship in the [`examples/`](https://github.com/parob/graphql-mcp/tree/main/examples) directory. Each one is also deployed live at [examples.graphql-mcp.com](https://examples.graphql-mcp.com).
+Runnable examples ship in the [`examples/`](https://github.com/parob/graphql-mcp/tree/main/examples) directory, each also deployed live at [examples.graphql-mcp.com](https://examples.graphql-mcp.com). The first four cover common use cases; a further five — under [GraphQL Library Examples](#graphql-library-examples) — demonstrate the same API across each popular GraphQL library.
 
 ## Hello World
 
@@ -136,12 +136,34 @@ app = server.http_app(transport="streamable-http", stateless_http=True)
 
 That's the entire file. `from_remote_url()` introspects the remote schema and generates read-only MCP tools automatically.
 
+## GraphQL Library Examples
+
+The same small "users" API, exposed through each popular GraphQL library — and each one demonstrating the [`@mcp` directive](/configuration#mcp-directive) (renaming a tool, renaming and hiding an argument, hiding a field). They're handy as copy-paste starting points for your own library.
+
+Every example exposes the same MCP surface:
+- `list_users` — a normal tool
+- `fetch_user` — `getUserById` renamed via `@mcp`, with its `userId` argument exposed as `id`
+- a hidden `internal_metrics` field and a hidden `debugToken` argument
+
+| Library | `@mcp` support | Source | Live demo |
+|---------|----------------|--------|-----------|
+| **graphql-api** | Native — decorator / `Annotated[...]` (recommended) | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphql_api.py) | [demo](https://examples.graphql-mcp.com/library-graphql-api/) |
+| **graphql-core** | Native — `@mcp` inline in SDL | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphql_core.py) | [demo](https://examples.graphql-mcp.com/library-graphql-core/) |
+| **Ariadne** | Native — `@mcp` in `type_defs` | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_ariadne.py) | [demo](https://examples.graphql-mcp.com/library-ariadne/) |
+| **Strawberry** | Workaround — `@strawberry.schema_directive` + SDL round-trip | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_strawberry.py) | [demo](https://examples.graphql-mcp.com/library-strawberry/) |
+| **Graphene** | Workaround — `apply_mcp()` | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphene.py) | [demo](https://examples.graphql-mcp.com/library-graphene/) |
+
+::: info `@mcp` is native for some libraries, a workaround for others
+The directive is first-class for graphql-api, graphql-core, and Ariadne. Strawberry and Graphene don't carry the directive onto the underlying graphql-core schema, so those examples apply it via a documented workaround. Basic tool exposure works natively everywhere — only `@mcp` customization needs the extra step. See [Strawberry & Graphene](/strawberry-graphene) for the full rundown.
+:::
+
 ## Running Locally
 
 ```bash
 cd examples
 uv sync
-uv run python hello_world.py   # or task_manager.py, nested_api.py, remote_api.py
+uv run python hello_world.py   # or task_manager.py, nested_api.py, remote_api.py,
+                               # or any of the library_*.py examples
 ```
 
 Then open `http://localhost:8002/graphql` (port varies per example) to see GraphiQL and the MCP Inspector.

--- a/docs/public/strawberry-graphene.md
+++ b/docs/public/strawberry-graphene.md
@@ -8,6 +8,10 @@ The [`@mcp` directive](/configuration#mcp-directive) relies on graphql-core's `a
 
 There are three supported paths to apply `@mcp` in this situation. **They are alternatives — pick one.** They do not stack.
 
+::: tip Runnable examples
+Copy-paste versions ship in the examples directory: [`library_strawberry.py`](https://github.com/parob/graphql-mcp/tree/main/examples/library_strawberry.py) (Path A) and [`library_graphene.py`](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphene.py) (Path B). See [Examples → GraphQL Library Examples](/examples#graphql-library-examples).
+:::
+
 ## Picking a path
 
 | Path | Strawberry | Graphene | When to use |

--- a/examples/app.py
+++ b/examples/app.py
@@ -38,20 +38,20 @@ EXAMPLES = [
      "remote_api.py"),
     # Per-library examples: the same small "users" API exposed through each
     # popular GraphQL library, each demonstrating the @mcp directive.
-    ("/library-graphql-api", library_graphql_api_app, "Library: graphql-api",
+    ("/library-graphql-api", library_graphql_api_app, "graphql-api",
      "graphql-api with native @mcp — rename/hide fields and arguments (recommended).",
      "library_graphql_api.py"),
-    ("/library-graphql-core", library_graphql_core_app, "Library: graphql-core",
+    ("/library-graphql-core", library_graphql_core_app, "graphql-core",
      "graphql-core with the @mcp directive declared inline in SDL.",
      "library_graphql_core.py"),
-    ("/library-ariadne", library_ariadne_app, "Library: Ariadne",
+    ("/library-ariadne", library_ariadne_app, "Ariadne",
      "Schema-first Ariadne with the @mcp directive in type_defs.",
      "library_ariadne.py"),
-    ("/library-strawberry", library_strawberry_app, "Library: Strawberry",
+    ("/library-strawberry", library_strawberry_app, "Strawberry",
      "Strawberry — basic exposure is native; @mcp needs a workaround "
      "(@strawberry.schema_directive + SDL round-trip).",
      "library_strawberry.py"),
-    ("/library-graphene", library_graphene_app, "Library: Graphene",
+    ("/library-graphene", library_graphene_app, "Graphene",
      "Graphene — basic exposure is native; @mcp isn't expressible in Graphene, "
      "so it's applied via the apply_mcp() workaround.",
      "library_graphene.py"),


### PR DESCRIPTION
## Why

The commit that removes the `Library:` prefix from the example cards (and adds the docs for the library examples) landed on the branch **after PR #10 had already been merged**, so it never reached `main`. As a result, the live examples site at [examples.graphql-mcp.com](https://examples.graphql-mcp.com) still shows cards titled "Library: …", and the docs don't yet mention the per-library examples.

This PR carries that single remaining commit so `main` (and both deploys) pick it up.

## Changes

- **`examples/app.py`**: remove the `Library:` prefix from the five per-library example cards → now `graphql-api`, `graphql-core`, `Ariadne`, `Strawberry`, `Graphene`. Merging this triggers the Cloud Run `deploy-examples.yml` redeploy, which updates the live examples site.
- **`docs/examples.md`**: add a **GraphQL Library Examples** section — a table of all five (source + live-demo links) with a note on native vs workaround `@mcp` support.
- **`docs/strawberry-graphene.md`**: link the runnable `library_strawberry.py` / `library_graphene.py` examples from the workaround guide.

Net diff: 3 files, docs + the example landing-page titles only.

## Verification

`vitepress build` → **BUILD_OK**; example suite **50 passed**; no `Library:` text remains in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DthKuN8eHrjWpEGQGQJisp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DthKuN8eHrjWpEGQGQJisp)_