### PR TITLE
Add MCP Inspector docs page + de-emphasize @mcp framing in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Built-in web interface for testing and debugging MCP tools:
 
 <img src="docs/.vitepress/public/images/mcp_inspector.png" alt="MCP Inspector Interface" width="600">
 
-The inspector is enabled by default — visit `/graphql` in your browser. See the [MCP Inspector documentation](https://graphql-mcp.com/docs/mcp-inspector/) for details.
+The inspector is enabled by default — visit `/graphql` in your browser. See the [MCP Inspector documentation](https://graphql-mcp.com/mcp-inspector) for details.
 
 ## Compatibility
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
             { text: 'Python Libraries', link: '/python-libraries' },
             { text: 'Remote APIs', link: '/existing-apis' },
             { text: 'Configuration', link: '/configuration' },
+            { text: 'MCP Inspector', link: '/mcp-inspector' },
             { text: 'Strawberry & Graphene', link: '/strawberry-graphene' },
           ]
         },

--- a/docs/public/examples.md
+++ b/docs/public/examples.md
@@ -145,17 +145,15 @@ Every example exposes the same MCP surface:
 - `fetch_user` — `getUserById` renamed via `@mcp`, with its `userId` argument exposed as `id`
 - a hidden `internal_metrics` field and a hidden `debugToken` argument
 
-| Library | `@mcp` support | Source | Live demo |
-|---------|----------------|--------|-----------|
-| **graphql-api** | Native — decorator / `Annotated[...]` (recommended) | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphql_api.py) | [demo](https://examples.graphql-mcp.com/library-graphql-api/) |
-| **graphql-core** | Native — `@mcp` inline in SDL | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphql_core.py) | [demo](https://examples.graphql-mcp.com/library-graphql-core/) |
-| **Ariadne** | Native — `@mcp` in `type_defs` | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_ariadne.py) | [demo](https://examples.graphql-mcp.com/library-ariadne/) |
-| **Strawberry** | Workaround — `@strawberry.schema_directive` + SDL round-trip | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_strawberry.py) | [demo](https://examples.graphql-mcp.com/library-strawberry/) |
-| **Graphene** | Workaround — `apply_mcp()` | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphene.py) | [demo](https://examples.graphql-mcp.com/library-graphene/) |
+| Library | Source | Live demo |
+|---------|--------|-----------|
+| **graphql-api** | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphql_api.py) | [demo](https://examples.graphql-mcp.com/library-graphql-api/) |
+| **graphql-core** | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphql_core.py) | [demo](https://examples.graphql-mcp.com/library-graphql-core/) |
+| **Ariadne** | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_ariadne.py) | [demo](https://examples.graphql-mcp.com/library-ariadne/) |
+| **Strawberry** | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_strawberry.py) | [demo](https://examples.graphql-mcp.com/library-strawberry/) |
+| **Graphene** | [source](https://github.com/parob/graphql-mcp/tree/main/examples/library_graphene.py) | [demo](https://examples.graphql-mcp.com/library-graphene/) |
 
-::: info `@mcp` is native for some libraries, a workaround for others
-The directive is first-class for graphql-api, graphql-core, and Ariadne. Strawberry and Graphene don't carry the directive onto the underlying graphql-core schema, so those examples apply it via a documented workaround. Basic tool exposure works natively everywhere — only `@mcp` customization needs the extra step. See [Strawberry & Graphene](/strawberry-graphene) for the full rundown.
-:::
+Strawberry and Graphene apply `@mcp` a little differently from the SDL-based libraries — see [Strawberry & Graphene](/strawberry-graphene) if you need the specifics.
 
 ## Running Locally
 

--- a/docs/public/mcp-inspector.md
+++ b/docs/public/mcp-inspector.md
@@ -1,0 +1,55 @@
+---
+title: "MCP Inspector"
+---
+
+# MCP Inspector
+
+The MCP Inspector is a built-in web interface for testing and debugging your generated MCP tools — no separate client needed. It's injected into GraphiQL and served alongside your GraphQL endpoint at `/graphql`.
+
+![MCP Inspector interface](/images/mcp_inspector.png)
+
+## Opening the Inspector
+
+Start any server with the GraphQL HTTP endpoint enabled (the default) and open `/graphql` in your browser:
+
+```python
+from graphql_api import GraphQLAPI, field
+from graphql_mcp.server import GraphQLMCP
+
+
+class API:
+    @field
+    def hello(self, name: str = "World") -> str:
+        """Say hello to someone."""
+        return f"Hello, {name}!"
+
+
+server = GraphQLMCP.from_api(GraphQLAPI(root_type=API))
+app = server.http_app()
+```
+
+Then visit `http://localhost:8002/graphql` (the port varies per app). The Inspector loads next to GraphiQL — switch to it from the GraphiQL plugins sidebar.
+
+::: tip Try it live
+The hosted examples expose the Inspector without installing anything — e.g. [examples.graphql-mcp.com/hello-world](https://examples.graphql-mcp.com/hello-world/).
+:::
+
+## What you can do
+
+- **Browse tools** — see every MCP tool generated from your schema, with its description.
+- **Execute tools** — call any tool with custom parameters and view the response.
+- **Inspect schemas** — view each tool's input parameters and output schema.
+- **Add authentication** — attach headers (e.g. a bearer token) to tool calls.
+- **Track history** — review previous tool calls and their results.
+
+The Inspector calls the same MCP endpoint your AI client uses, so what you see is exactly what an agent sees.
+
+## Enabling and disabling
+
+The Inspector ships with the GraphQL HTTP endpoint, which is **enabled by default**. To serve MCP only (no GraphiQL, no Inspector), disable the HTTP endpoint:
+
+```python
+server = GraphQLMCP.from_api(api, graphql_http=False)
+```
+
+See [Configuration](/configuration) for related HTTP options.

--- a/examples/app.py
+++ b/examples/app.py
@@ -39,21 +39,19 @@ EXAMPLES = [
     # Per-library examples: the same small "users" API exposed through each
     # popular GraphQL library, each demonstrating the @mcp directive.
     ("/library-graphql-api", library_graphql_api_app, "graphql-api",
-     "graphql-api with native @mcp — rename/hide fields and arguments (recommended).",
+     "Expose a graphql-api app as MCP tools, customized with the @mcp directive.",
      "library_graphql_api.py"),
     ("/library-graphql-core", library_graphql_core_app, "graphql-core",
-     "graphql-core with the @mcp directive declared inline in SDL.",
+     "Expose a graphql-core schema as MCP tools, customized with the @mcp directive.",
      "library_graphql_core.py"),
     ("/library-ariadne", library_ariadne_app, "Ariadne",
-     "Schema-first Ariadne with the @mcp directive in type_defs.",
+     "Expose a schema-first Ariadne API as MCP tools, customized with the @mcp directive.",
      "library_ariadne.py"),
     ("/library-strawberry", library_strawberry_app, "Strawberry",
-     "Strawberry — basic exposure is native; @mcp needs a workaround "
-     "(@strawberry.schema_directive + SDL round-trip).",
+     "Expose a Strawberry API as MCP tools, customized with the @mcp directive.",
      "library_strawberry.py"),
     ("/library-graphene", library_graphene_app, "Graphene",
-     "Graphene — basic exposure is native; @mcp isn't expressible in Graphene, "
-     "so it's applied via the apply_mcp() workaround.",
+     "Expose a Graphene API as MCP tools, customized with the @mcp directive.",
      "library_graphene.py"),
 ]
 

--- a/examples/library_ariadne.py
+++ b/examples/library_ariadne.py
@@ -1,16 +1,10 @@
-"""Ariadne + @mcp — basic exposure and MCP customization.
+"""Ariadne → MCP tools, customized with the @mcp directive.
 
-Demonstrates, for the schema-first Ariadne library:
-- Basic exposure: every Query/Mutation field becomes an MCP tool.
-- The @mcp directive written directly in the SDL `type_defs`, which Ariadne
-  preserves on the schema AST so graphql-mcp can read it:
-    - rename a field's tool  (getUserById → fetch_user)
-    - rename + describe an argument  (userId → id)
-    - hide an argument from MCP  (debugToken)
-    - hide a whole field from MCP  (internalMetrics)
+Exposes a small "users" API and uses @mcp to rename a tool
+(getUserById → fetch_user), rename and describe an argument (userId → id),
+hide an argument (debugToken), and hide a field (internalMetrics).
 
-Because Ariadne is schema-first, the @mcp directive works natively — just
-declare it in your SDL and apply it inline. No rebuild step required.
+With schema-first Ariadne you declare and apply @mcp inline in your SDL type_defs.
 """
 
 from ariadne import QueryType, make_executable_schema

--- a/examples/library_graphene.py
+++ b/examples/library_graphene.py
@@ -1,27 +1,12 @@
-"""Graphene + @mcp — basic exposure, plus a WORKAROUND for @mcp.
+"""Graphene → MCP tools, customized with the @mcp directive.
 
-⚠️  @mcp is NOT native to Graphene. Graphene can't express directives in
-Python at all, so a plain Graphene schema carries no @mcp metadata for
-graphql-mcp to read. Basic exposure (every field → an MCP tool) works out of
-the box; @mcp customization requires the workaround below. See the guide:
-https://graphql-mcp.com/strawberry-graphene
+Exposes a small "users" API and uses @mcp to rename a tool
+(get_user_by_id → fetch_user), rename and describe an argument (user_id → id),
+hide an argument (debug_token), and hide a field (internal_metrics).
 
-Demonstrates, for the code-first Graphene library:
-- Basic exposure (native): every Query/Mutation field becomes an MCP tool. If
-  you don't need @mcp, just pass `graphene.Schema(...).graphql_schema` to
-  GraphQLMCP.
-- @mcp customization (WORKAROUND): rename/describe/hide fields and arguments
-  via `apply_mcp()` (Path B in the guide).
-
-Why `apply_mcp` rather than an SDL round-trip? Printing-then-rebuilding the SDL
-would drop Graphene's camelCase→snake_case argument mapping (`out_name`),
-breaking resolvers. `apply_mcp` attaches the @mcp configuration directly onto
-the existing graphql-core schema, keyed by `"Type.field"` / `"Type.field.arg"`,
-so nothing is rebuilt and the mapping is preserved.
-
-Caveat: `apply_mcp` config is private metadata — it shapes MCP exposure but is
-invisible to GraphQL introspection and `str(schema)`. That's fine for MCP, but
-don't rely on it being visible to other schema consumers.
+Note: with Graphene you apply @mcp via `apply_mcp()`, which attaches the config
+to the graphql-core schema directly (keyed by "Type.field" / "Type.field.arg").
+More in the Strawberry & Graphene guide: https://graphql-mcp.com/strawberry-graphene
 """
 
 import graphene

--- a/examples/library_graphql_api.py
+++ b/examples/library_graphql_api.py
@@ -1,16 +1,11 @@
-"""graphql-api + @mcp — basic exposure and MCP customization (recommended).
+"""graphql-api → MCP tools, customized with the @mcp directive.
 
-Demonstrates, for the decorator-based graphql-api library:
-- Basic exposure: each @field becomes an MCP tool automatically.
-- The unified @mcp directive, used natively:
-    - rename a field's tool  (get_user_by_id → fetch_user)
-    - rename + describe an argument  (user_id → id)
-    - hide an argument from MCP  (debug_token)
-    - hide a whole field from MCP  (internal_metrics)
+Exposes a small "users" API and uses @mcp to rename a tool
+(get_user_by_id → fetch_user), rename and describe an argument (user_id → id),
+hide an argument (debug_token), and hide a field (internal_metrics).
 
-graphql-api has the tightest integration: import `mcp` from graphql_mcp and
-apply it directly as a decorator (on fields) or inside `Annotated[...]`
-(on arguments). Pass `directives=[mcp]` to GraphQLAPI so it's registered.
+With graphql-api you apply @mcp directly: as a decorator on fields and inside
+Annotated[...] on arguments (and pass directives=[mcp] to GraphQLAPI).
 """
 
 from typing import Annotated, Optional

--- a/examples/library_graphql_core.py
+++ b/examples/library_graphql_core.py
@@ -1,17 +1,10 @@
-"""graphql-core + @mcp — basic exposure and MCP customization.
+"""graphql-core → MCP tools, customized with the @mcp directive.
 
-Demonstrates, for the reference graphql-core library:
-- Basic exposure: every Query/Mutation field becomes an MCP tool.
-- The @mcp directive written directly in SDL, which graphql-core preserves on
-  the schema AST so graphql-mcp can read it:
-    - rename a field's tool  (getUserById → fetch_user)
-    - rename + describe an argument  (userId → id)
-    - hide an argument from MCP  (debugToken)
-    - hide a whole field from MCP  (internalMetrics)
+Exposes a small "users" API and uses @mcp to rename a tool
+(getUserById → fetch_user), rename and describe an argument (userId → id),
+hide an argument (debugToken), and hide a field (internalMetrics).
 
-Because graphql-core is the common denominator every other library compiles
-down to, the @mcp directive "just works" here with no rebuild step — you only
-need to declare the directive in your SDL.
+With graphql-core you declare and apply @mcp inline in your SDL.
 """
 
 from graphql import build_schema

--- a/examples/library_strawberry.py
+++ b/examples/library_strawberry.py
@@ -1,31 +1,14 @@
-"""Strawberry + @mcp — basic exposure, plus a WORKAROUND for @mcp.
+"""Strawberry → MCP tools, customized with the @mcp directive.
 
-⚠️  @mcp is NOT native to Strawberry. Strawberry builds its own GraphQL types
-and does not carry the @mcp directive onto the underlying graphql-core AST, so
-a plain Strawberry schema loses the directive metadata before graphql-mcp ever
-sees it. Basic exposure (every field → an MCP tool) works out of the box; @mcp
-customization requires one of the workarounds documented in the guide:
+Exposes a small "users" API and uses @mcp to rename a tool
+(get_user_by_id → fetch_user), rename and describe an argument (user_id → id),
+hide an argument (debug_token), and hide a field (internal_metrics).
+
+Note: with Strawberry you declare @mcp as a `@strawberry.schema_directive` and
+round-trip the schema through SDL (`build_schema(str(schema))`) so the directive
+reaches the graphql-core AST, then copy resolvers across. Other approaches (e.g.
+`apply_mcp()`) are in the Strawberry & Graphene guide:
 https://graphql-mcp.com/strawberry-graphene
-
-Demonstrates, for the type-hint-based Strawberry library:
-- Basic exposure (native): every Strawberry field becomes an MCP tool. If you
-  don't need @mcp, just pass `strawberry.Schema(...)._schema` to GraphQLMCP.
-- @mcp customization (WORKAROUND): rename/describe/hide fields and arguments
-  via Strawberry's own `@schema_directive`, then round-trip through SDL.
-
-The workaround shown here (Path A in the guide):
-
-    1. Declare a `@strawberry.schema_directive` named `Mcp`.
-    2. Attach it to fields/arguments via `directives=[...]`.
-    3. Round-trip the schema through SDL: `build_schema(str(strawberry_schema))`.
-       Strawberry prints the directive into the SDL, so graphql-core preserves
-       it on the AST where graphql-mcp can read it.
-    4. Copy the resolvers across — `build_schema` doesn't carry them.
-
-Caveats: the resolver-copy step is required, and this only covers top-level
-query/mutation resolvers. For less ceremony, `apply_mcp()` (Path B in the
-guide) attaches the same config directly onto the graphql-core schema — see
-library_graphene.py for that approach.
 """
 
 from typing import Annotated, Optional

--- a/examples/test_libraries.py
+++ b/examples/test_libraries.py
@@ -9,11 +9,8 @@ library, basic exposure works AND the @mcp customizations take effect:
 - internal_metrics    -> hidden field, not exposed
 - debug_token         -> hidden argument, not exposed
 
-Note: @mcp is native for graphql-api, graphql-core and Ariadne. For Strawberry
-and Graphene it is NOT native — those examples apply @mcp via a documented
-workaround (see https://graphql-mcp.com/strawberry-graphene). These tests
-assert the workarounds produce the same end result, so they double as
-regression guards that the workarounds keep working.
+Each library applies @mcp slightly differently (see the individual example
+files); these tests assert all five produce the same MCP result.
 """
 
 import pytest


### PR DESCRIPTION
## Why

Two commits landed on the branch **after PR #11 was merged**, so they never reached `main` and aren't deployed:

1. The MCP Inspector docs page — so `https://graphql-mcp.com/mcp-inspector` (linked from the README) currently 404s.
2. The de-emphasis of the `@mcp` native-vs-workaround framing in the examples.

This PR carries both so `main` and the docs/examples deploys pick them up.

## Changes

### MCP Inspector docs page (fixes a dead README link)
The README linked to `https://graphql-mcp.com/docs/mcp-inspector/`, which 404s — the page never existed and the docs site serves pages at the root (no `/docs/` prefix).
- Add `docs/public/mcp-inspector.md` (what it is, how to open it at `/graphql`, what it does, enable/disable via `graphql_http`).
- Add it to the Guides sidebar in `config.ts`.
- Fix the README link → `https://graphql-mcp.com/mcp-inspector`.

### De-emphasize the `@mcp` native-vs-workaround framing
Whether a library carries `@mcp` natively or applies it via a small extra step isn't the point of the examples, so it's demoted from the headline to a footnote:
- Rewrite all five library example docstrings to a uniform, concise form; the per-library `@mcp` mechanism is now a one-line note (dropped the ⚠️ / "NOT native" / "WORKAROUND" framing).
- `examples/app.py`: uniform, neutral card descriptions.
- `docs/examples.md`: drop the "@mcp support: Native/Workaround" column and info box; reduce to a single footnote sentence.
- `test_libraries.py`: neutral one-line note.

The detailed rundown still lives in the dedicated Strawberry & Graphene guide.

## Verification

`vitepress build` → **BUILD_OK** (new page compiles, nav resolves, no dead links); example suite **50 passed**; flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DthKuN8eHrjWpEGQGQJisp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DthKuN8eHrjWpEGQGQJisp)_