### PR TITLE
fix: reconstruct tool-wrapper params as KEYWORD_ONLY

### DIFF
--- a/graphql_mcp/server.py
+++ b/graphql_mcp/server.py
@@ -1260,7 +1260,13 @@ def _create_tool_function(
             default = inspect.Parameter.empty
         else:
             default = arg_def.default_value
-        kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
+        # KEYWORD_ONLY (not POSITIONAL_OR_KEYWORD): the wrapper is invoked purely
+        # by keyword (**kwargs), and keyword-only params have no positional
+        # ordering constraint. This lets a GraphQL field legally place an
+        # optional argument (one with a default) before a required one — which
+        # POSITIONAL_OR_KEYWORD forbids ("non-default argument follows default
+        # argument") when reconstructing the signature.
+        kind = inspect.Parameter.KEYWORD_ONLY
         parameters.append(
             inspect.Parameter(mcp_arg_name, kind, default=default,
                               annotation=annotation_type)
@@ -1825,9 +1831,12 @@ def _create_recursive_tool_function(
                 else inspect.Parameter.empty
             )
             parameters.append(
+                # KEYWORD_ONLY: the wrapper is called only by keyword, and this
+                # lifts the positional ordering constraint so an optional arg may
+                # precede a required one without "non-default follows default".
                 inspect.Parameter(
                     param_name,
-                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
                     default=default,
                     annotation=python_type,
                 )
@@ -2135,7 +2144,13 @@ def _create_remote_tool_function(
         else:
             default = arg_def.default_value
 
-        kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
+        # KEYWORD_ONLY (not POSITIONAL_OR_KEYWORD): the wrapper is invoked purely
+        # by keyword (**kwargs), and keyword-only params have no positional
+        # ordering constraint. This lets a GraphQL field legally place an
+        # optional argument (one with a default) before a required one — which
+        # POSITIONAL_OR_KEYWORD forbids ("non-default argument follows default
+        # argument") when reconstructing the signature.
+        kind = inspect.Parameter.KEYWORD_ONLY
         parameters.append(
             inspect.Parameter(mcp_arg_name, kind, default=default,
                               annotation=annotation_type)
@@ -2287,9 +2302,12 @@ def _create_recursive_remote_tool_function(
                 else inspect.Parameter.empty
             )
             parameters.append(
+                # KEYWORD_ONLY: the wrapper is called only by keyword, and this
+                # lifts the positional ordering constraint so an optional arg may
+                # precede a required one without "non-default follows default".
                 inspect.Parameter(
                     param_name,
-                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
                     default=default,
                     annotation=python_type,
                 )

--- a/tests/test_optional_before_required_args.py
+++ b/tests/test_optional_before_required_args.py
@@ -1,0 +1,52 @@
+"""Regression: a GraphQL field may declare an optional argument (one with a
+default) *before* a required one. The tool-wrapper signature is reconstructed
+with KEYWORD_ONLY parameters, so this no longer raises the CPython
+``ValueError: non-default argument follows default argument`` it used to.
+
+The wrappers are invoked purely by keyword (**kwargs), so keyword-only is the
+faithful kind — and it lifts the positional ordering constraint.
+"""
+import inspect
+
+from graphql import (
+    GraphQLArgument,
+    GraphQLField,
+    GraphQLNonNull,
+    GraphQLObjectType,
+    GraphQLSchema,
+    GraphQLString,
+)
+
+from graphql_mcp.server import _create_tool_function
+
+
+def _build_field():
+    """A field whose *optional* arg (``reason``, has a default) is declared
+    before its *required* arg (``message``, non-null, no default)."""
+    return GraphQLField(
+        GraphQLString,
+        args={
+            "reason": GraphQLArgument(GraphQLString, default_value="audit"),
+            "message": GraphQLArgument(GraphQLNonNull(GraphQLString)),
+        },
+    )
+
+
+def test_optional_arg_before_required_arg_builds():
+    field = _build_field()
+    schema = GraphQLSchema(query=GraphQLObjectType("Query", {"send": field}))
+
+    # Previously raised ValueError: non-default argument follows default argument
+    wrapper = _create_tool_function("send", field, schema)
+
+    sig = inspect.signature(wrapper)
+    assert "reason" in sig.parameters
+    assert "message" in sig.parameters
+
+    # Both are keyword-only — that's what makes the ordering legal.
+    assert sig.parameters["reason"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert sig.parameters["message"].kind is inspect.Parameter.KEYWORD_ONLY
+
+    # Optional/required is still driven by the presence of a default, unchanged.
+    assert sig.parameters["reason"].default == "audit"
+    assert sig.parameters["message"].default is inspect.Parameter.empty


### PR DESCRIPTION
## Problem

The MCP tool wrappers are invoked purely by keyword (`**kwargs`), but their reconstructed `__signature__` marked every parameter `POSITIONAL_OR_KEYWORD` in GraphQL-argument order. When a field declares an **optional argument (one with a default) before a required one**, `inspect.Signature` raises:

```
ValueError: non-default argument follows default argument
```

…even though the underlying call is keyword-only and perfectly valid. This crashes MCP server construction for any schema with that argument layout.

## Fix

Mark the reconstructed parameters `KEYWORD_ONLY` across all four builders (local + remote, flat + recursive). This is faithful — nothing is ever passed positionally — and lifts the ordering constraint. Required/optional is still driven solely by the presence of a default, so **generated tool schemas are unchanged**.

## Verification

- New regression test reproduces the exact `ValueError` on old code and passes with the fix.
- Full suite: **379 passed, 1 skipped** (stable across repeated runs).
- The library never reads `param.kind` anywhere — it only writes it — so nothing branches on the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)